### PR TITLE
Database-backed rate limiting for OTP sends

### DIFF
--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -41,6 +41,22 @@ export const createAuthOptions = (ctx: GenericCtx<DataModel>) => {
   return {
     baseURL: siteUrl,
     database: authComponent.adapter(ctx),
+    // Better Auth's default rate limiting uses in-memory storage, which is
+    // meaningless across Convex's ephemeral isolates — store windows in the
+    // database instead. The OTP send endpoint triggers real Resend emails
+    // from an unauthenticated route, so it gets a tight per-IP rule.
+    rateLimit: {
+      enabled: true,
+      storage: "database",
+      // Global window also bounds expired-row pruning; keep it >= the longest
+      // custom rule below so those windows aren't pruned early.
+      window: 60,
+      max: 100,
+      customRules: {
+        "/email-otp/send-verification-otp": { window: 60, max: 6 },
+        "/sign-in/email-otp": { window: 60, max: 10 },
+      },
+    },
     plugins: [
       emailOTP({
         otpLength: 6,

--- a/convex/betterAuth/_generated/component.ts
+++ b/convex/betterAuth/_generated/component.ts
@@ -103,6 +103,10 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                   publicKey: string;
                 };
                 model: "jwks";
+              }
+            | {
+                data: { count: number; key: string; lastRequest: number };
+                model: "rateLimit";
               };
           onCreateHandle?: string;
           select?: Array<string>;
@@ -306,6 +310,33 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "createdAt"
                     | "expiresAt"
                     | "_id";
+                  mode?: "sensitive" | "insensitive";
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "not_in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
+              }
+            | {
+                model: "rateLimit";
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: "key" | "count" | "lastRequest" | "_id";
                   mode?: "sensitive" | "insensitive";
                   operator?:
                     | "lt"
@@ -558,6 +589,33 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | Array<number>
                     | null;
                 }>;
+              }
+            | {
+                model: "rateLimit";
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: "key" | "count" | "lastRequest" | "_id";
+                  mode?: "sensitive" | "insensitive";
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "not_in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
               };
           onDeleteHandle?: string;
         },
@@ -576,7 +634,8 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
             | "account"
             | "verification"
             | "passkey"
-            | "jwks";
+            | "jwks"
+            | "rateLimit";
           offset?: number;
           paginationOpts: {
             cursor: string | null;
@@ -627,7 +686,8 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
             | "account"
             | "verification"
             | "passkey"
-            | "jwks";
+            | "jwks"
+            | "rateLimit";
           select?: Array<string>;
           where?: Array<{
             connector?: "AND" | "OR";
@@ -931,6 +991,34 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | Array<number>
                     | null;
                 }>;
+              }
+            | {
+                model: "rateLimit";
+                update: { count?: number; key?: string; lastRequest?: number };
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: "key" | "count" | "lastRequest" | "_id";
+                  mode?: "sensitive" | "insensitive";
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "not_in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
               };
           onUpdateHandle?: string;
           paginationOpts: {
@@ -1198,6 +1286,34 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "createdAt"
                     | "expiresAt"
                     | "_id";
+                  mode?: "sensitive" | "insensitive";
+                  operator?:
+                    | "lt"
+                    | "lte"
+                    | "gt"
+                    | "gte"
+                    | "eq"
+                    | "in"
+                    | "not_in"
+                    | "ne"
+                    | "contains"
+                    | "starts_with"
+                    | "ends_with";
+                  value:
+                    | string
+                    | number
+                    | boolean
+                    | Array<string>
+                    | Array<number>
+                    | null;
+                }>;
+              }
+            | {
+                model: "rateLimit";
+                update: { count?: number; key?: string; lastRequest?: number };
+                where?: Array<{
+                  connector?: "AND" | "OR";
+                  field: "key" | "count" | "lastRequest" | "_id";
                   mode?: "sensitive" | "insensitive";
                   operator?:
                     | "lt"

--- a/convex/betterAuth/generatedSchema.ts
+++ b/convex/betterAuth/generatedSchema.ts
@@ -85,6 +85,12 @@ export const tables = {
     createdAt: v.number(),
     expiresAt: v.optional(v.union(v.null(), v.number())),
   }),
+  rateLimit: defineTable({
+    key: v.string(),
+    count: v.number(),
+    lastRequest: v.number(),
+  })
+    .index("key", ["key"]),
 };
 
 const schema = defineSchema(tables);

--- a/convex/betterAuth/schema.ts
+++ b/convex/betterAuth/schema.ts
@@ -17,6 +17,9 @@ const schema = defineSchema({
   // index the component logs a missing-index warning and falls back to a
   // full table scan.
   passkey: tables.passkey.index("credentialID", ["credentialID"]),
+  // The rate limiter prunes expired windows by lastRequest (the generated
+  // schema already indexes key for the per-request lookups).
+  rateLimit: tables.rateLimit.index("lastRequest", ["lastRequest"]),
 });
 
 export default schema;


### PR DESCRIPTION
Post-cut-over security follow-up from the migration's final review: the public send-verification-otp endpoint triggered real Resend sends with no effective production rate limit (Better Auth's default limiter is in-memory, meaningless across Convex isolates).

- rateLimit storage: database (rateLimit table generated + lastRequest prune index; key index came with generation)
- Custom rules: /email-otp/send-verification-otp 6/min per IP; /sign-in/email-otp 10/min per IP
- Global window raised to 60s so pruning can't reset the 60s rules early (prune cutoff uses the global window)

Verified on dev: 6×200 then 429 with persistence across 20s; DB row keyed by real client IP (per-client bucketing through the proxy chain confirmed): `82.4.x.x|/email-otp/send-verification-otp`, count capped at 6.