### PR TITLE
feat: show join code and starter in admin games table

### DIFF
--- a/app/admin/games/page.tsx
+++ b/app/admin/games/page.tsx
@@ -11,6 +11,9 @@ import { formatDuration } from "@/lib/admin/metrics";
 type GameRow = {
   _id: string;
   _creationTime: number;
+  joinCode: string;
+  createdBy: string;
+  createdByName: string | null;
   partySize: number;
   totalRounds: number;
   finished: boolean;
@@ -18,6 +21,8 @@ type GameRow = {
 };
 
 const columns: Column<GameRow>[] = [
+  { header: "Join code", cell: (g) => <span className="font-mono">{g.joinCode}</span> },
+  { header: "Started by", cell: (g) => g.createdByName ?? <span className="font-mono text-muted-foreground">{g.createdBy}</span> },
   { header: "Party", cell: (g) => g.partySize },
   { header: "Rounds", cell: (g) => g.totalRounds },
   { header: "Finished", cell: (g) => (g.finished ? <Badge>Yes</Badge> : <Badge variant="outline">No</Badge>) },

--- a/convex/admin.ts
+++ b/convex/admin.ts
@@ -140,9 +140,13 @@ export const listGames = query({
           .query("players")
           .withIndex("byGame", (q) => q.eq("gameId", game._id))
           .collect();
+        const creator = players.find((p) => p.userId === game.createdBy);
         return {
           _id: game._id,
           _creationTime: game._creationTime,
+          joinCode: game.joinCode,
+          createdBy: game.createdBy,
+          createdByName: creator?.displayName ?? null,
           partySize: players.length,
           totalRounds: game.totalRounds,
           finished: game.completedAt !== undefined,


### PR DESCRIPTION
## Summary
Adds two columns to the admin panel's games table:
- **Join code** — the game's `joinCode` (monospace).
- **Started by** — display name of the game creator (player whose `userId` matches `createdBy`), falling back to the raw user id when no matching player is found.

## Changes
- `convex/admin.ts` (`listGames`): return `joinCode`, `createdBy`, and `createdByName` (resolved from already-collected players — no extra queries).
- `app/admin/games/page.tsx`: render the two new columns.

## Testing
- `npx tsc --noEmit` passes.